### PR TITLE
Implements optional dead letter queues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,21 @@ Also see:
 - [Architect Data changelog](https://github.com/arc-repos/arc-data/blob/master/changelog.md)
 ---
 
+## [5.6.1] - 2019-04-05
+
+### Added
+
+- Enables creation of dead letter queues associated to a queue.
+- `maxReceiveCount` is required 
+- Example: 
+  ```
+  @queues
+  myqueue
+  myqueuewithdeadletter
+    maxReceiveCount 10
+  ```
+
+---
 
 ## [5.6.0] - 2019-04-04
 

--- a/src/create/aws/create-queue-lambda-code/index.js
+++ b/src/create/aws/create-queue-lambda-code/index.js
@@ -1,17 +1,18 @@
 let assert = require('@smallwins/validate/assert')
 let createCode = require('../_create-code')
 
+
 module.exports = function _createLambdaCode(params, callback) {
 
   assert(params, {
-    queue: String,
+    queue: typeof params.queue === 'object' ? Object : String,
     app: String,
     arc: Object,
   })
 
   createCode({
     space: 'queues',
-    idx: params.queue,
+    idx: typeof params.queue === 'object' ? Object.keys(params)[0] : params.queue,
     app: params.app,
     arc: params.arc,
   }, callback)

--- a/src/create/aws/create-queue-lambda-deployments/index.js
+++ b/src/create/aws/create-queue-lambda-deployments/index.js
@@ -6,29 +6,30 @@ let _create = require('./_create-lambda')
 module.exports = function _createDeployments(params, callback) {
   assert(params, {
     app: String,
-    queue: String,
+    queue: typeof params.queue === 'object' ? Object : String,
   })
+  var name = typeof params.queue === 'object' ? Object.keys(params.queue)[0] : params.queue
   parallel({
     staging(callback) {
       _create({
         app: params.app,
         queue: params.queue,
-        name: `${params.app}-staging-${params.queue}`
+        name: `${params.app}-staging-${name}`
       }, callback)
     },
     production(callback) {
       _create({
         app: params.app,
         queue: params.queue,
-        name: `${params.app}-production-${params.queue}`
+        name: `${params.app}-production-${name}`
       }, callback)
     },
   },
-  function _done(err) {
-    if (err) {
-      console.log(err)
-    }
-    callback()
-  })
+    function _done(err) {
+      if (err) {
+        console.log(err)
+      }
+      callback()
+    })
 }
 

--- a/src/create/aws/create-queue/index.js
+++ b/src/create/aws/create-queue/index.js
@@ -4,26 +4,67 @@ var aws = require('aws-sdk')
 
 /**
  * creates two queues
+ * optional: creates associated deadletter queue when maxReceiveCount is specified
  *
  * - appname-staging-queue
  * - appname-production-queue
+ *
  */
+
 module.exports = function _createSQS(params, callback) {
 
   assert(params, {
     app: String,
-    queue: String
+    queue: typeof params.queue === 'object' ? Object : String,
   })
 
+  var name = params.queue
+  var attrs = {}
+  var sqs = new aws.SQS({ region: process.env.AWS_REGION })
+
+  if (typeof params.queue === 'object') {
+    name = Object.keys(params.queue)[0] // myqueuename
+    attrs = params.queue[name] // { maxReceiveCount: 10 }
+  }
+
+  function createDeadLetterQueue(env, callback, queueName) {
+    sqs.createQueue({ QueueName: `${queueName}-deadletter` },
+      function _createQueue(err, data) {
+        if (err) {
+          console.log(err)
+          callback();
+        } else {
+          var params = {
+            QueueUrl: data.queueUrl,
+            AttributeNames: ['QueueArn']
+          }
+          sqs.getQueueAttributes(params, function _getQueueAttributes(err, data) {
+            if (err) {
+              console.log(err);
+              callback();
+            }
+            callback(data.Attributes.QueueArn);
+          });
+        }
+      })
+  }
+
+  function createPrimaryQueue(env, callback, queueName, config = {}) {
+    sqs.createQueue({ QueueName: queueName, ...config },
+      function _createQueue(err) {
+        if (err) console.log(err)
+        callback()
+      })
+  }
+
   function createQueue(env, callback) {
-    let sqs = new aws.SQS({region: process.env.AWS_REGION})
-    sqs.createQueue({
-      QueueName: `${params.app}-${env}-${params.queue}`,
-    },
-    function _createQueue(err) {
-      if (err) console.log(err)
-      callback()
-    })
+    var queueName = `${params.app}-${env}-${name}`
+    var config = {}
+    if (attrs.maxReceiveCount) {
+      config.Attributes = { RedrivePolicy: { maxReceiveCount: attrs.maxReceiveCount } }
+      createDeadLetterQueue(env, function _setArn(arn) { config.Attributes.RedrivePolicy.deadLetterTargetArn = arn }, queueName)
+    }
+    createPrimaryQueue(env, callback, queueName, config)
   }
 
   // create two topics, one for staging one for prod
@@ -35,10 +76,10 @@ module.exports = function _createSQS(params, callback) {
     staging,
     production
   ],
-  function _done(err) {
-    if (err) {
-      console.log(err)
-    }
-    callback()
-  })
+    function _done(err) {
+      if (err) {
+        console.log(err)
+      }
+      callback()
+    })
 }

--- a/test/_slow_integration_tests/create/07-queues-mock.arc
+++ b/test/_slow_integration_tests/create/07-queues-mock.arc
@@ -4,3 +4,5 @@ testapp
 @queues
 test-queue
 test-queue-two
+test-queue-with-deadletter
+  maxReceiveCount 10

--- a/test/_slow_integration_tests/create/07-queues.js
+++ b/test/_slow_integration_tests/create/07-queues.js
@@ -1,30 +1,29 @@
 let fs = require('fs')
-let print = require('../../src/create/_print')
+let print = require('../../../src/create/_print')
 let parse = require('@architect/parser')
-var nukeLambdas = require('./_nuke-lambdas')
-var nukeTopics = require('./_nuke-topics')
+// var nukeLambdas = require('./_nuke-lambdas')
+// var nukeTopics = require('./_nuke-topics')
 var path = require('path')
-var rm = require('rimraf').sync
+// var rm = require('rimraf').sync
 var mkdir = require('mkdirp').sync
 var cp = require('fs').copyFileSync
 var test = require('tape')
-var run = require('../../src/create')
+var run = require('../../../src/create')
 
-test('env', t=> {
+test('env', t => {
   t.plan(1)
   t.ok(run, 'run exists')
 })
 
-test('setup', t=> {
+test('setup', t => {
   t.plan(1)
   mkdir('test/create/_mock')
-  cp('test/create/07-queues-mock.arc', 'test/create/_mock/.arc')
+  cp(path.join(__dirname, '07-queues-mock.arc'), 'test/create/_mock/.arc')
   process.chdir('test/create/_mock')
   t.ok(true, 'created test/_mock/.arc')
-  console.log(process.cwd())
 })
 
-test('exec', t=> {
+test('exec', t => {
   t.plan(1)
   let arcPath = path.join(process.cwd(), '.arc')
   let raw = fs.readFileSync(arcPath).toString()


### PR DESCRIPTION
This updates the arc file to handle optional parameters for queues. Specifically, it allows for the creation of a dead letter queue.  

>Amazon SQS supports dead-letter queues, which other queues (source queues) can target for messages that can't be processed (consumed) successfully. Dead-letter queues are useful for debugging your application or messaging system because they let you isolate problematic messages to determine why their processing doesn't succeed.

Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html. 

This does not include any breaking changes, instead it extends the existing queue implementation. 

```.arc
@queues
firstqueue
queuewithdeadletter
  maxReceiveCount 10
```

The above example would create 3 queues, but only generate the lambdas for `firstqueue` and `queuewithdeadletter`. A third queue would be created, but associated to the `queuewithdeadletter` through the aws RedrivePolicy attribute.   


Thank you for helping out! ✨

Before submitting a pull request, please make sure the you checked the following:

- [x] Forked the repository and created your branch from master
- [x] Make sure the tests pass! `npm it` in the repository root
- [x] If you've fixed a bug or added code **more** tests are appreciated
- [x] If you're adding a new command, removing an old command, or changing how a command works, please update the relevant documentation for the command (under the `doc/` folder)
- [x] Summarize your changes in the [changelog](https://github.com/arc-repos/architect/blob/master/changelog.md)
- [x] If you haven't already please complete the CLA

Learn more about contributing: https://arc.codes/intro/community