### PR TITLE
fixing invalid docs for removing env variables

### DIFF
--- a/src/help/index.js
+++ b/src/help/index.js
@@ -51,7 +51,7 @@ get the current version`,
 Read and write environment variables. Sensitive configuration data, such as API keys, needs to happen outside of the codebase in revision control and you can use this tool to ensure an entire team and the deployment targets are in sync.
 ${g(`arc env`)} ${d('..............................................................displays environment variables for the current .arc')}
 ${g(`arc env [testing|staging|production] [VARIABLE_NAME] [value]`)} ${d('.........assigns a value to the environment variable')}
-${g(`arc env [testing|staging|production] remove [VARIABLE_NAME]`)} ${d('..........removes environment variable from environment')}
+${g(`arc env remove [testing|staging|production] [VARIABLE_NAME]`)} ${d('..........removes environment variable from environment')}
 `
 }
 


### PR DESCRIPTION
The help syntax for the `env remove` command was invalid for architect@617. This PR corrects the help file to match the syntax which works.