### PR TITLE
bump eslint to v7, bump github ci to use newer nodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [windows-latest, ubuntu-latest, macOS-latest]
 
     # Go

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "rc": "npm version prerelease --preid RC"
   },
+  "engines": {
+    "node" : ">=10"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/architect/architect.git"
@@ -55,7 +58,7 @@
   },
   "devDependencies": {
     "codecov": "^3.6.5",
-    "eslint": "^6.8.0",
+    "eslint": "^7.0.0",
     "nyc": "^15.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.1",


### PR DESCRIPTION
This supersedes #804

Bump eslint up to 7, add an `engines` field to package.json requiring node v10 or newer, and update the github ci matrix to test on v10, v12 and v14.

If this is satisfactory, should I send similar PRs to the other repos?