### PR TITLE
use quotes to glob tests with tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "npm run lint && npm run test:integration && npm run coverage",
-    "test:unit": "tape test/unit/*-test.js test/unit/**/*-test.js test/unit/**/**/*-test.js| tap-spec",
-    "test:integration": "tape test/integration/*-test.js | tap-spec",
+    "test:unit": "tape 'test/unit/**/*-test.js' | tap-spec",
+    "test:integration": "tape 'test/integration/**/*-test.js' | tap-spec",
     "lint": "eslint . --fix",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "rc": "npm version prerelease --preid RC"


### PR DESCRIPTION
2 integration test and 101 unit test runs before this change. same after this change. prevent us from missing running tests if we add deeper directory hierarchies for tests moving forward.