### PR TITLE
bump destroy to 1.1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [8.4.9] 2021-02-28
+
+### Added
+
+- `arc destroy` now removes CloudWatch Log Groups, `arc env`-added environment variables and the S3 deployment bucket when run, in addition to removing the CloudFormation Stack.
+
+---
+
 ## [8.4.8] 2021-02-01
 
 ### Added
@@ -17,7 +25,7 @@
 ### Added
 
 - New `--no-hydrate` flag to `arc deploy` in case you want arc to skip installing / managing dependencies within functions before a deploy.
-- Added `installRoot` param to `@architect/hydrate` API for explicitly enabling root dependencies to be installed`
+- Added `installRoot` param to `@architect/hydrate` API for explicitly enabling root dependencies to be installed
 - Added `npx` bin for standalone CLI usage of Hydrate (`npx arc-hydrate`)
 
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@architect/create": "1.3.3",
     "@architect/deploy": "2.4.0",
-    "@architect/destroy": "1.0.4",
+    "@architect/destroy": "1.1.0",
     "@architect/env": "1.2.0",
     "@architect/hydrate": "1.9.5",
     "@architect/logs": "2.0.1",

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -82,12 +82,12 @@ ${g(`arc env`)} ${d('...........................................................
 `,
 
   destroy: `${G('arc destroy')}
-Destroy your current project's CloudFormation Stack. Removes all resources associated with your arc app. Unless --production is specified, this command will destroy your staging Stack.
+Destroy your current project's CloudFormation Stack. Deletes all resources associated with your arc app (including environment variables, CloudWatch Logs and deployment bucket). Unless --production is specified, this command will destroy your staging Stack.
 
 ${D('Options')}
   ${g(`--name`)} ${d('......... name of your app (required)')}
-  ${g(`--force`)} ${d('........ destroy an app that has database tables and/or static assets. Note: if the static S3 bucket is not empty, this command will fail.')}
-  ${g(`--production`)} ${d('... destroy the production Stack of your app')}
+  ${g(`--force`)} ${d('........ destroy an app that has database tables and/or static assets')}
+  ${g(`--production`)} ${d('... destroy the production version of your app')}
 `,
 
   logs: `${G('arc logs [options] <path/to/function>')}


### PR DESCRIPTION
allowing for complete deletion of all arc-related AWS bits. fixes #1076
