### PR TITLE
bump destroy and hydrate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@
 
 ---
 
+## [8.5.4] 2021-04-12
+
+### Fixed
+
+- Fixed hydration of `src/shared` folder to plugin-generated Lambda functions; fixes [#1116](https://github.com/architect/architect/issues/1116)
+- Fixed error during `arc destroy` if either `@static` or deployment S3 bucket no longer exists (could happen during a previous `arc destroy` incomplete execution or crash); bucket removal during `destroy` is now idempotent
+
+---
+
 ## [8.5.3] 2021-03-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "@architect/create": "1.4.1",
     "@architect/deploy": "2.5.1",
-    "@architect/destroy": "1.1.0",
+    "@architect/destroy": "1.1.1",
     "@architect/env": "1.2.0",
-    "@architect/hydrate": "1.9.6",
+    "@architect/hydrate": "1.9.7",
     "@architect/logs": "2.1.0",
     "@architect/package": "6.2.0",
     "@architect/sandbox": "3.4.1",


### PR DESCRIPTION
destroy S3 bucket removal is now idempotent and hydrate now copies src/shared into plugin-generated Lambda directories