### PR TITLE
Fix typo in view hydration shortcut help copy

### DIFF
--- a/src/help/index.js
+++ b/src/help/index.js
@@ -58,7 +58,7 @@ ${D('Options')}
 ${D('Keyboard Shortcuts')}
 ${d('Sandbox registers a few keyboard shortcuts you may invoke to help with local development (note: they are all capital letters!):')}
   ${g('S')} ${d('..... re-hydrates (installs dependencies) `src/shared` and copies or symlinks it into all function code')}
-  ${g('S')} ${d('..... re-hydrates (installs dependencies) `src/views` and copies or symlinks it into all function code')}
+  ${g('V')} ${d('..... re-hydrates (installs dependencies) `src/views` and copies or symlinks it into all function code')}
   ${g('H')} ${d('..... re-hydrates (installs dependencies) both `src/shared` and `src/views` and copies or symlinks both into all function code')}
 `,
 


### PR DESCRIPTION
Tested this out in an app and confirmed via logs that this should be `S` for `shared` and `V` for `views`.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
