### PR TITLE
feat: show help when providing `-h` or `--help` CLI flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-arc",
     "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-arc",
     "lint": "eslint . --fix",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "rc": "npm version prerelease --preid RC"
   },
   "engines": {

--- a/src/help/index.js
+++ b/src/help/index.js
@@ -8,13 +8,14 @@ let b = chalk.bold
 let helps = {
   help: `${G('arc [command] <options>')}
 
-${chalk.grey.bold('Usage')}
-  ${g('arc', G('init'), '[name or path]')} ${d('................... initialize project files')}
+${D('Global Commands')}
+  ${g('arc', G('<init|create>'), '[name or path]')} ${d('.......... initialize project files')}
+  ${g('arc', G('help'), '<command>')} ${d('........................ get help')}
+  ${g('arc', G('version'))} ${d('............................... get the current version')}
+${D('Project Commands')}
   ${g('arc', G('sandbox'))} ${d('............................... start a local arc development server')}
   ${g('arc', G('deploy'), '[direct|static|production]')} ${d('..... deploy to AWS')}
   ${g('arc', G('logs'), 'path/to/fn', '[production|destroy]')} ${d('.. manage function logs')}
-  ${g('arc', G('help'), '<command>')} ${d('........................ get help')}
-  ${g('arc', G('version'))} ${d('............................... get the current version')}
   ${g('arc', G('env'))} ${d('................................... work with environment variables')}
   ${g('arc', G('destroy'))} ${d('............................... destroy your current project')}
 `,

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ let cmds = {
   destroy,
   env,
   hydrate,
+  '-h': help,
+  '--help': help,
   help,
   logs,
   sandbox,
@@ -58,13 +60,17 @@ async function main (args) {
 
   let cmd = args.shift()
   let opts = args.slice(0)
+  let helpFlag = opts.some(f => [ '-h', '--help' ].includes(f))
 
   if (cmd && !cmds[cmd]) {
     pretty.notFound(cmd)
-    process.exit(1)
+    return false
   }
-  else if (!cmd || cmd === 'help') {
+  else if (!cmd || cmd === 'help' || cmd === '-h' || cmd === '--help') {
     help(opts)
+  }
+  else if (helpFlag) {
+    help([ cmd ])
   }
   else {
     try {
@@ -78,9 +84,10 @@ async function main (args) {
       // Unpause the Sandbox watcher
       pauser.unpause()
       pretty.fail(cmd, err)
-      process.exit(1)
+      return false
     }
   }
+  return true
 }
 
 module.exports = main
@@ -88,6 +95,9 @@ module.exports = main
 // allow direct invoke
 if (require.main === module) {
   (async function () {
-    await main()
+    let ok = await main()
+    if (!ok) {
+      process.exit(1)
+    }
   })()
 }

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -9,7 +9,7 @@ test('cli module exits without error and prints usage from the shell', t => {
     if (err) t.fail(err)
     else {
       t.ok(true, 'exited with non-zero code')
-      t.match(stdout, /usage/i, 'stdout includes the word "usage"')
+      t.match(stdout, /global commands/i, 'stdout includes the word "global commands"')
     }
   })
 })

--- a/test/unit/src/index-test.js
+++ b/test/unit/src/index-test.js
@@ -30,21 +30,46 @@ let arc = proxyquire('../../../src', {
 
 
 test('Help (and defaults)', t => {
-  t.plan(9)
+  t.plan(21)
   arc([])
   t.equal(returned.cmd, './help', 'No arg defaults to help')
-  t.equal(returned.params.length, 0, 'No options passed')
-  t.notOk(bannered, 'Did not print banner')
+  t.equal(returned.params.length, 0, '..no options passed')
+  t.notOk(bannered, '..did not print banner')
 
   arc([ 'help' ])
-  t.equal(returned.cmd, './help', 'Requesting help succeeds')
-  t.equal(returned.params.length, 0, 'No options passed')
-  t.notOk(bannered, 'Did not print banner')
+  t.equal(returned.cmd, './help', 'Requesting help via `arc help` succeeds')
+  t.equal(returned.params.length, 0, '..no options passed')
+  t.notOk(bannered, '..did not print banner')
+  reset()
+
+  arc([ '--help' ])
+  t.equal(returned.cmd, './help', 'Requesting --help succeeds')
+  t.equal(returned.params.length, 0, '..no options passed')
+  t.notOk(bannered, '..did not print banner')
+  reset()
+
+  arc([ '-h' ])
+  t.equal(returned.cmd, './help', 'Requesting help via -h succeeds')
+  t.equal(returned.params.length, 0, '..no options passed')
+  t.notOk(bannered, '..did not print banner')
+  reset()
 
   arc([ 'help', 'sandbox' ])
   t.equal(returned.cmd, './help', 'Requesting help with a command succeeds')
-  t.equal(returned.params.length, 1, `Options passed: ${returned.params[0]}`)
-  t.notOk(bannered, 'Did not print banner')
+  t.equal(returned.params.length, 1, `..options passed: ${returned.params[0]}`)
+  t.notOk(bannered, '..did not print banner')
+  reset()
+
+  arc([ 'sandbox', '-h' ])
+  t.equal(returned.cmd, './help', 'Requesting help via -h with a command succeeds')
+  t.equal(returned.params.length, 1, `..options passed: ${returned.params[0]}`)
+  t.notOk(bannered, '..did not print banner')
+  reset()
+
+  arc([ 'sandbox', '--help' ])
+  t.equal(returned.cmd, './help', 'Requesting help via --help with a command succeeds')
+  t.equal(returned.params.length, 1, `..options passed: ${returned.params[0]}`)
+  t.notOk(bannered, '..did not print banner')
   reset()
 })
 


### PR DESCRIPTION
also:
- have `src/index.js` return a boolean to signal process exit code, making it easier to test. also added tests for the conditions it should exit with code 1
- print full coverage report when running unit tests w/ coverage
- split main `help` text output into "Global Commands" and "Project Commands"

Bumps coverage up from ~38% to ~60%.