### PR TITLE
Add ARC_DB_EXTERNAL to CLI help

### DIFF
--- a/src/help/index.js
+++ b/src/help/index.js
@@ -81,6 +81,7 @@ ${D('Options')}
   ${g(`-d${d(',')} --debug`)} ${d('....................... print even more detailed information for debugging')}
 
 ${D('Environment Variables')}
+  ${d(`${g('ARC_DB_EXTERNAL')} ................... use an external DynamoDB tool (such as AWS NoSQL Workbench)`)}
   ${d(`${g('ARC_HTTP_PORT')}, ${g('PORT')} ............... set the HTTP server port (same as --port)`)}
   ${d(`${g('ARC_EVENTS_PORT')} ................... set the events/queues service port (default 4444)`)}
   ${d(`${g('ARC_TABLES_PORT')} ................... set the DynamoDB emulator port (default 5555)`)}


### PR DESCRIPTION
It is already documented on the arc.codes site, but was missing from the CLI help.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
